### PR TITLE
Forkable uups

### DIFF
--- a/development/contracts/mixin/ForkableUUPS.sol
+++ b/development/contracts/mixin/ForkableUUPS.sol
@@ -1,30 +1,43 @@
 pragma solidity ^0.8.17;
 
-import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
-import "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
-import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
-import "./ForkStructure.sol";
+import {AccessControlUpgradeable} from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {ForkableStructure} from "./ForkableStructure.sol";
 
 abstract contract ForkableUUPS is
-    ForkStructure,
+    ForkableStructure,
     UUPSUpgradeable,
     AccessControlUpgradeable
 {
+    /// @dev The following role is allowed to trigger the upgrade of the implementation contract
     bytes32 public constant UPDATER = keccak256("UPDATER");
 
-    function initialize(address _forkmanager, address _parentContract) public virtual override(ForkStructure) onlyInitializing {
-        ForkStructure.initialize(_forkmanager, _parentContract);
+    function initialize(
+        address _forkmanager,
+        address _parentContract,
+        address _updater
+    ) public virtual onlyInitializing {
+        ForkableStructure.initialize(_forkmanager, _parentContract);
+        _setupRole(UPDATER, _updater);
     }
 
+    /// @dev The _authorizeUpgrade is overriding the abstract function from UUPSUpgradeable
     function _authorizeUpgrade(address) internal view override {
-        require(hasRole(UPDATER, msg.sender));
+        require(hasRole(UPDATER, msg.sender), "Caller is not an updater");
     }
 
+    /// @dev Internal function to create the children contracts.
+    ///
+    /// @param implementation Allows to pass a different implementation contract for the second proxied child.
     function _createChildren(
         address implementation
     ) internal returns (address forkingManager1, address forkingManager2) {
+        // Fork 1 will always keep the original implementation
         forkingManager1 = address(new ERC1967Proxy(_getImplementation(), ""));
         children[0] = forkingManager1;
+        // Fork 2 can introduce a new implementation, if a different implementation contract
+        // is passed in
         forkingManager2 = address(new ERC1967Proxy(implementation, ""));
         children[1] = forkingManager2;
     }

--- a/development/contracts/mixin/ForkableUUPS.sol
+++ b/development/contracts/mixin/ForkableUUPS.sol
@@ -1,0 +1,31 @@
+pragma solidity ^0.8.17;
+
+import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import "@openzeppelin/contracts/proxy/utils/UUPSUpgradeable.sol";
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import "./ForkStructure.sol";
+
+abstract contract ForkableUUPS is
+    ForkStructure,
+    UUPSUpgradeable,
+    AccessControlUpgradeable
+{
+    bytes32 public constant UPDATER = keccak256("UPDATER");
+
+    function initialize(address _forkmanager, address _parentContract) public virtual override(ForkStructure) onlyInitializing {
+        ForkStructure.initialize(_forkmanager, _parentContract);
+    }
+
+    function _authorizeUpgrade(address) internal view override {
+        require(hasRole(UPDATER, msg.sender));
+    }
+
+    function _createChildren(
+        address implementation
+    ) internal returns (address forkingManager1, address forkingManager2) {
+        forkingManager1 = address(new ERC1967Proxy(_getImplementation(), ""));
+        children[0] = forkingManager1;
+        forkingManager2 = address(new ERC1967Proxy(implementation, ""));
+        children[1] = forkingManager2;
+    }
+}

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,3 +1,4 @@
 ds-test/=lib/forge-std/lib/ds-test/src/
 forge-std/=lib/forge-std/src/
 @openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/
+@openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/

--- a/test/ForkableUUPS.t.sol
+++ b/test/ForkableUUPS.t.sol
@@ -1,0 +1,70 @@
+pragma solidity ^0.8.17;
+
+import {Test} from "forge-std/Test.sol";
+import {ForkableUUPSWrapper} from "./testcontract/ForkableUUPSWrapper.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {Utils} from "./utils/Utils.sol";
+
+contract ForkableUUPSTest is Test {
+    ForkableUUPSWrapper public forkableUUPS;
+
+    bytes32 internal constant _IMPLEMENTATION_SLOT =
+        0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+
+    address public forkmanager = address(0x123);
+    address public parentContract = address(0x456);
+    address public updater =
+        address(0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38);
+    address public forkableUUPSImplementation;
+
+    function setUp() public {
+        forkableUUPSImplementation = address(new ForkableUUPSWrapper());
+        forkableUUPS = ForkableUUPSWrapper(
+            address(new ERC1967Proxy(forkableUUPSImplementation, ""))
+        );
+        forkableUUPS.initialize(forkmanager, parentContract, updater);
+    }
+
+    function testInitialize() public {
+        assertEq(forkableUUPS.forkmanager(), forkmanager);
+        assertEq(forkableUUPS.parentContract(), parentContract);
+        assertTrue(forkableUUPS.hasRole(forkableUUPS.UPDATER(), updater));
+    }
+
+    function testCreateChildren() public {
+        address secondForkableUUPSImplementation = address(
+            new ForkableUUPSWrapper()
+        );
+
+        (address child1, address child2) = forkableUUPS.createChildren(
+            secondForkableUUPSImplementation
+        );
+
+        // child1 and child2 addresses should not be zero address
+        assertTrue(child1 != address(0));
+        assertTrue(child2 != address(0));
+
+        // the implementation address of children should match the expected ones
+        assertEq(
+            Utils.bytesToAddress(
+                vm.load(address(child1), _IMPLEMENTATION_SLOT)
+            ),
+            forkableUUPSImplementation
+        );
+        assertEq(
+            Utils.bytesToAddress(
+                vm.load(address(child2), _IMPLEMENTATION_SLOT)
+            ),
+            secondForkableUUPSImplementation
+        );
+    }
+
+    function testUpdaterUpgradeAuthorization() public {
+        assertTrue(forkableUUPS.hasRole(forkableUUPS.UPDATER(), updater));
+        vm.prank(updater);
+        forkableUUPS.authorizationCheck(updater);
+
+        vm.expectRevert(bytes("Caller is not an updater"));
+        forkableUUPS.authorizationCheck(updater);
+    }
+}

--- a/test/ForkableUUPS.t.sol
+++ b/test/ForkableUUPS.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.17;
 import {Test} from "forge-std/Test.sol";
 import {ForkableUUPSWrapper} from "./testcontract/ForkableUUPSWrapper.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
-import {Utils} from "./utils/Utils.sol";
+import {Util} from "./utils/Util.sol";
 
 contract ForkableUUPSTest is Test {
     ForkableUUPSWrapper public forkableUUPS;
@@ -46,13 +46,13 @@ contract ForkableUUPSTest is Test {
 
         // the implementation address of children should match the expected ones
         assertEq(
-            Utils.bytesToAddress(
+            Util.bytesToAddress(
                 vm.load(address(child1), _IMPLEMENTATION_SLOT)
             ),
             forkableUUPSImplementation
         );
         assertEq(
-            Utils.bytesToAddress(
+            Util.bytesToAddress(
                 vm.load(address(child2), _IMPLEMENTATION_SLOT)
             ),
             secondForkableUUPSImplementation

--- a/test/testcontract/ForkableUUPSWrapper.sol
+++ b/test/testcontract/ForkableUUPSWrapper.sol
@@ -1,0 +1,23 @@
+pragma solidity ^0.8.17;
+
+import {ForkableUUPS} from "../../development/contracts/mixin/ForkableUUPS.sol";
+
+contract ForkableUUPSWrapper is ForkableUUPS {
+    function initialize(
+        address _forkmanager,
+        address _parentContract,
+        address _updater
+    ) public override initializer {
+        ForkableUUPS.initialize(_forkmanager, _parentContract, _updater);
+    }
+
+    function createChildren(
+        address implementation
+    ) public returns (address, address) {
+        return _createChildren(implementation);
+    }
+
+    function authorizationCheck(address _dummy) public view {
+        _authorizeUpgrade(_dummy);
+    }
+}

--- a/test/utils/Util.sol
+++ b/test/utils/Util.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.8.17;
 
-library Utils {
+library Util {
     function bytesToAddress(bytes32 b) public pure returns (address) {
         return address(uint160(uint256(b)));
     }

--- a/test/utils/utils.sol
+++ b/test/utils/utils.sol
@@ -1,0 +1,7 @@
+pragma solidity ^0.8.17;
+
+library Utils {
+    function bytesToAddress(bytes32 b) public pure returns (address) {
+        return address(uint160(uint256(b)));
+    }
+}


### PR DESCRIPTION
The new contract implements the UUPS pattern and can later be inherited by all contracts that we require updatable.