### PR TITLE
ForkableGlobalExitRoot manager

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "lib/openzeppelin-contracts-upgradeable"]
 	path = lib/openzeppelin-contracts-upgradeable
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable
+[submodule "lib/zkevm-contracts"]
+	path = lib/zkevm-contracts
+	url = https://github.com/RealityETH/zkevm-contracts

--- a/development/contracts/ForkableGlobalExitRoot.sol
+++ b/development/contracts/ForkableGlobalExitRoot.sol
@@ -1,0 +1,59 @@
+pragma solidity ^0.8.17;
+
+import {PolygonZkEVMGlobalExitRoot} from "@RealityETH/zkevm-contracts/contracts/inheritedMainContracts/PolygonZkEVMGlobalExitRoot.sol";
+import {TokenWrapped} from "@RealityETH/zkevm-contracts/contracts/lib/TokenWrapped.sol";
+import {IERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import {ForkableUUPS} from "./mixin/ForkableUUPS.sol";
+import {ForkableStructure} from "./mixin/ForkableStructure.sol";
+
+contract ForkableGlobalExitRoot is ForkableUUPS, PolygonZkEVMGlobalExitRoot {
+
+    /// @dev Initializting function
+    /// @param _forkmanager The address of the forkmanager
+    /// @param _parentContract The address of the parent contract
+    /// @param _rollupAddress The address of the rollup contract
+    /// @param _bridgeAddress The address of the bridge contract
+    function initialize(
+        address _forkmanager,
+        address _parentContract,
+        address _rollupAddress,
+        address _bridgeAddress
+    ) public initializer {
+        ForkableUUPS.initialize(_forkmanager, _parentContract, msg.sender);
+        PolygonZkEVMGlobalExitRoot.initialize(_rollupAddress, _bridgeAddress);
+        _setupRole(DEFAULT_ADMIN_ROLE, msg.sender);
+    }
+
+    /// @dev Overrites the other initialize functions from ForkableStructure and PolygonZkEVMGlobalExitRoot
+    /// @notice If we would not do it, it would throw the following error:
+    /// "Derived contract must override function "initialize". Two or more base classes
+    /// define function with same name and parameter types."
+    function initialize(
+        address forkmanager,
+        address parentContract
+    )
+        public
+        virtual
+        override(ForkableStructure, PolygonZkEVMGlobalExitRoot)
+        onlyInitializing
+    {
+        revert(
+            string(
+                abi.encode(
+                    "illicit call to initialize with arguments:",
+                    forkmanager,
+                    parentContract
+                )
+            )
+        );
+    }
+
+    /// @dev Public interface to create children. This can only be done by the forkmanager
+    /// @param implementation Allows to pass a different implementation contract for the second proxied child.
+    /// @return The addresses of the two children
+    function createChildren(
+        address implementation
+    ) external onlyForkManger returns (address, address) {
+        return _createChildren(implementation);
+    }
+}

--- a/development/contracts/mixin/ForkableStructure.sol
+++ b/development/contracts/mixin/ForkableStructure.sol
@@ -29,7 +29,7 @@ contract ForkableStructure is IForkableStructure, Initializable {
     }
 
     modifier onlyForkManger() {
-        require(msg.sender == forkmanager, "Only avaialble for fork");
+        require(msg.sender == forkmanager, "Only forkManager is allowed");
         _;
     }
 

--- a/remappings.txt
+++ b/remappings.txt
@@ -2,3 +2,4 @@ ds-test/=lib/forge-std/lib/ds-test/src/
 forge-std/=lib/forge-std/src/
 @openzeppelin/contracts-upgradeable/=lib/openzeppelin-contracts-upgradeable/contracts/
 @openzeppelin/contracts/=lib/openzeppelin-contracts/contracts/
+@RealityETH/zkevm-contracts/=lib/zkevm-contracts

--- a/test/ForkableGlobalExitRoot.t.sol
+++ b/test/ForkableGlobalExitRoot.t.sol
@@ -1,0 +1,85 @@
+pragma solidity ^0.8.17;
+
+import {Test} from "forge-std/Test.sol";
+import {ForkableGlobalExitRoot} from "../development/contracts/ForkableGlobalExitRoot.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {Util} from "./utils/Util.sol";
+
+contract ForkableGlobalExitRootTest is Test {
+    ForkableGlobalExitRoot public forkableGlobalExitRoot;
+
+    bytes32 internal constant _IMPLEMENTATION_SLOT =
+        0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+
+    address public forkmanager = address(0x123);
+    address public parentContract = address(0x456);
+    address public updater =
+        address(0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38);
+    address public rollupAddress = address(0x789);
+    address public bridgeAddress = address(0xabc);
+    address public forkableGlobalExitRootImplementation;
+
+    function setUp() public {
+        forkableGlobalExitRootImplementation = address(
+            new ForkableGlobalExitRoot()
+        );
+        forkableGlobalExitRoot = ForkableGlobalExitRoot(
+            address(new ERC1967Proxy(forkableGlobalExitRootImplementation, ""))
+        );
+        forkableGlobalExitRoot.initialize(
+            forkmanager,
+            parentContract,
+            rollupAddress,
+            bridgeAddress
+        );
+    }
+
+    function testInitialize() public {
+        assertEq(forkableGlobalExitRoot.forkmanager(), forkmanager);
+        assertEq(forkableGlobalExitRoot.parentContract(), parentContract);
+        assertTrue(
+            forkableGlobalExitRoot.hasRole(
+                forkableGlobalExitRoot.DEFAULT_ADMIN_ROLE(),
+                address(this)
+            )
+        );
+    }
+
+    function testCreateChildren() public {
+        address secondForkableGlobalExitRootImplementation = address(
+            new ForkableGlobalExitRoot()
+        );
+        vm.prank(forkableGlobalExitRoot.forkmanager());
+        (address child1, address child2) = forkableGlobalExitRoot
+            .createChildren(secondForkableGlobalExitRootImplementation);
+
+        // child1 and child2 addresses should not be zero address
+        assertTrue(child1 != address(0));
+        assertTrue(child2 != address(0));
+
+        // the implementation address of children should match the expected ones
+        assertEq(
+            Util.bytesToAddress(vm.load(address(child1), _IMPLEMENTATION_SLOT)),
+            forkableGlobalExitRootImplementation
+        );
+        assertEq(
+            Util.bytesToAddress(vm.load(address(child2), _IMPLEMENTATION_SLOT)),
+            secondForkableGlobalExitRootImplementation
+        );
+    }
+
+    function testCreateChildrenOnlyByForkManager() public {
+        address secondForkableGlobalExitRootImplementation = address(
+            new ForkableGlobalExitRoot()
+        );
+
+        vm.expectRevert("Only forkManager is allowed");
+        forkableGlobalExitRoot.createChildren(
+            secondForkableGlobalExitRootImplementation
+        );
+        vm.prank(forkableGlobalExitRoot.forkmanager());
+        forkableGlobalExitRoot.createChildren(
+            secondForkableGlobalExitRootImplementation
+        );
+    }
+}

--- a/test/ForkableUUPS.t.sol
+++ b/test/ForkableUUPS.t.sol
@@ -46,15 +46,11 @@ contract ForkableUUPSTest is Test {
 
         // the implementation address of children should match the expected ones
         assertEq(
-            Util.bytesToAddress(
-                vm.load(address(child1), _IMPLEMENTATION_SLOT)
-            ),
+            Util.bytesToAddress(vm.load(address(child1), _IMPLEMENTATION_SLOT)),
             forkableUUPSImplementation
         );
         assertEq(
-            Util.bytesToAddress(
-                vm.load(address(child2), _IMPLEMENTATION_SLOT)
-            ),
+            Util.bytesToAddress(vm.load(address(child2), _IMPLEMENTATION_SLOT)),
             secondForkableUUPSImplementation
         );
     }


### PR DESCRIPTION
The GlobalExitRoot contract is part of the polygon zkevm responsible to manage the exit root hash in various scenario. We need to fork this contract, if we wanna fork the whole system. Hence, we create a forkable version of it here.