### PR TITLE
zkevm prototype

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -2,6 +2,7 @@
   "extends": "solhint:recommended",
   "plugins": ["prettier"],
   "rules": {
-    "compiler-version": "off"
+    "compiler-version": "off",
+    "max-states-count": "off"
   }
 }

--- a/development/contracts/ForkableZkEVM.sol
+++ b/development/contracts/ForkableZkEVM.sol
@@ -1,0 +1,144 @@
+pragma solidity ^0.8.17;
+
+import {PolygonZkEVM} from "@RealityETH/zkevm-contracts/contracts/inheritedMainContracts/PolygonZkEVM.sol";
+import {IPolygonZkEVMGlobalExitRoot} from "@RealityETH/zkevm-contracts/contracts/interfaces/IPolygonZkEVMGlobalExitRoot.sol";
+import {IVerifierRollup} from "@RealityETH/zkevm-contracts/contracts/interfaces/IVerifierRollup.sol";
+import {IPolygonZkEVMBridge} from "@RealityETH/zkevm-contracts/contracts/interfaces/IPolygonZkEVMBridge.sol";
+
+import {TokenWrapped} from "@RealityETH/zkevm-contracts/contracts/lib/TokenWrapped.sol";
+import {IERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import {IForkableZkEVM} from "./interfaces/IForkableZkEVM.sol";
+import {ForkableUUPS} from "./mixin/ForkableUUPS.sol";
+
+contract ForkableZkEVM is ForkableUUPS, IForkableZkEVM, PolygonZkEVM {
+    // @inheritdoc IForkableZkEVM
+    function initialize(
+        address _forkmanager,
+        address _parentContract,
+        InitializePackedParameters calldata initializePackedParameters,
+        bytes32 genesisRoot,
+        string memory _trustedSequencerURL,
+        string memory _networkName,
+        string calldata _version,
+        IPolygonZkEVMGlobalExitRoot _globalExitRootManager,
+        IERC20Upgradeable _matic,
+        IVerifierRollup _rollupVerifier,
+        IPolygonZkEVMBridge _bridgeAddress
+    ) external initializer {
+        ForkableUUPS.initialize(_forkmanager, _parentContract, msg.sender);
+        PolygonZkEVM.initialize(
+            initializePackedParameters,
+            genesisRoot,
+            _trustedSequencerURL,
+            _networkName,
+            _version,
+            _globalExitRootManager,
+            _matic,
+            _rollupVerifier,
+            _bridgeAddress
+        );
+    }
+
+    // @inheritdoc IForkableZkEVM
+    function createChildren(
+        address implementation
+    ) external onlyForkManger returns (address, address) {
+        return _createChildren(implementation);
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // For the following functions a modifier called: onlyBeforeForking is added.
+    // This ensure that the functions do not change the consolidated state after forking.
+    ///////////////////////////////////////////////////////////////////////////
+
+    modifier onlyBeforeForking() {
+        require(children[0] == address(0x0), "No changes after forking");
+        _;
+    }
+
+    function verifyBatches(
+        uint64 pendingStateNum,
+        uint64 initNumBatch,
+        uint64 finalNewBatch,
+        bytes32 newLocalExitRoot,
+        bytes32 newStateRoot,
+        bytes calldata proof
+    ) public override onlyBeforeForking {
+        PolygonZkEVM.verifyBatches(
+            pendingStateNum,
+            initNumBatch,
+            finalNewBatch,
+            newLocalExitRoot,
+            newStateRoot,
+            proof
+        );
+    }
+
+    function verifyBatchesTrustedAggregator(
+        uint64 pendingStateNum,
+        uint64 initNumBatch,
+        uint64 finalNewBatch,
+        bytes32 newLocalExitRoot,
+        bytes32 newStateRoot,
+        bytes calldata proof
+    ) public override onlyBeforeForking onlyTrustedAggregator {
+        PolygonZkEVM.verifyBatchesTrustedAggregator(
+            pendingStateNum,
+            initNumBatch,
+            finalNewBatch,
+            newLocalExitRoot,
+            newStateRoot,
+            proof
+        );
+    }
+
+    function consolidatePendingState(
+        uint64 pendingStateNum
+    ) public override onlyBeforeForking {
+        PolygonZkEVM.consolidatePendingState(pendingStateNum);
+    }
+
+    function overridePendingState(
+        uint64 initPendingStateNum,
+        uint64 finalPendingStateNum,
+        uint64 initNumBatch,
+        uint64 finalNewBatch,
+        bytes32 newLocalExitRoot,
+        bytes32 newStateRoot,
+        bytes calldata proof
+    ) public override onlyBeforeForking {
+        PolygonZkEVM.overridePendingState(
+            initPendingStateNum,
+            finalPendingStateNum,
+            initNumBatch,
+            finalNewBatch,
+            newLocalExitRoot,
+            newStateRoot,
+            proof
+        );
+    }
+
+    // @dev: sequenceBatches can also change the consolidated state, and hence its prohibited to be called
+    // after forking.
+    function sequenceBatches(
+        BatchData[] calldata batches,
+        address l2Coinbase
+    ) public override onlyBeforeForking {
+        PolygonZkEVM.sequenceBatches(batches, l2Coinbase);
+    }
+
+    // @dev: The function proveNonDeterministicPendingState() should still be callable, as it
+    // does not change the state root and only raises an emergency event.
+
+    // @dev The activateEmergencyState modifier is not changed, as we will always want to be able to
+    // itervene as an admin.
+    // function activateEmergencyState()
+
+    // @dev This deactivateEmergencyState modifier is not changed, as we will always want to be able to
+    // itervene as an admin.
+    // function deactivateEmergencyState()
+
+    // @dev People will be allowed to force batches, because they can never be verified anyways
+    // and hence will not have any impact on the state root.
+    // See functions  sequenceForceBatches and forceBatch in the PolygonZkEVM contract.
+}

--- a/development/contracts/ForkableZkEVM.sol
+++ b/development/contracts/ForkableZkEVM.sol
@@ -81,7 +81,7 @@ contract ForkableZkEVM is ForkableUUPS, IForkableZkEVM, PolygonZkEVM {
         bytes32 newLocalExitRoot,
         bytes32 newStateRoot,
         bytes calldata proof
-    ) public override onlyBeforeForking onlyTrustedAggregator {
+    ) public override onlyBeforeForking {
         PolygonZkEVM.verifyBatchesTrustedAggregator(
             pendingStateNum,
             initNumBatch,

--- a/development/contracts/WhitelistArbitrator.sol
+++ b/development/contracts/WhitelistArbitrator.sol
@@ -67,6 +67,7 @@ contract WhitelistArbitrator is BalanceHolder {
         uint256 price;
         uint256 reserved_ts;
     }
+
     mapping(bytes32 => TokenReservation) public token_reservations;
     uint256 public reserved_tokens;
 

--- a/development/contracts/WhitelistArbitrator.sol
+++ b/development/contracts/WhitelistArbitrator.sol
@@ -67,7 +67,6 @@ contract WhitelistArbitrator is BalanceHolder {
         uint256 price;
         uint256 reserved_ts;
     }
-
     mapping(bytes32 => TokenReservation) public token_reservations;
     uint256 public reserved_tokens;
 

--- a/development/contracts/interfaces/IForkableZkEVM.sol
+++ b/development/contracts/interfaces/IForkableZkEVM.sol
@@ -1,0 +1,44 @@
+pragma solidity ^0.8.17;
+
+import {IForkableStructure} from "./IForkableStructure.sol";
+import {IPolygonZkEVM} from "@RealityETH/zkevm-contracts/contracts/interfaces/IPolygonZkEVM.sol";
+import {IPolygonZkEVMGlobalExitRoot} from "@RealityETH/zkevm-contracts/contracts/interfaces/IPolygonZkEVMGlobalExitRoot.sol";
+import {IERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import {IVerifierRollup} from "@RealityETH/zkevm-contracts/contracts/interfaces/IVerifierRollup.sol";
+import {IPolygonZkEVMBridge} from "@RealityETH/zkevm-contracts/contracts/interfaces/IPolygonZkEVMBridge.sol";
+
+interface IForkableZkEVM is IForkableStructure, IPolygonZkEVM {
+    // @dev: This function is used to initialize the contract.
+    // @params forkmanager: The address of the forkmanager contract.
+    // @params parentContract: The address of the parent contract.
+    // @params initializePackedParameters: The packed parameters for the initialization of the contract.
+    // @params genesisRoot: The genesis root of the contract.
+    // @params _trustedSequencerURL: The URL of the trusted sequencer.
+    // @params _networkName: The name of the network.
+    // @params _version: The version of the contract.
+    // @params _globalExitRootManager: The address of the global exit root manager.
+    // @params _matic: The address of the forkable token to pay sequencer fees
+    // @params _rollupVerifier: The address of the rollup verifier.
+    // @params _bridgeAddress: The address of the bridge contract.
+    function initialize(
+        address forkmanager,
+        address parentContract,
+        InitializePackedParameters calldata initializePackedParameters,
+        bytes32 genesisRoot,
+        string memory _trustedSequencerURL,
+        string memory _networkName,
+        string calldata _version,
+        IPolygonZkEVMGlobalExitRoot _globalExitRootManager,
+        IERC20Upgradeable _matic,
+        IVerifierRollup _rollupVerifier,
+        IPolygonZkEVMBridge _bridgeAddress
+    ) external;
+
+    // @dev: This function is used to create the children contracts.
+    // The initialization of the children contracts should be called in the same transaction
+    // as the creation of the children contracts.
+    // @params implemation: The implementation of the children contracts.
+    function createChildren(
+        address implementation
+    ) external returns (address, address);
+}

--- a/test/ForkableZkEVM.t.sol
+++ b/test/ForkableZkEVM.t.sol
@@ -176,7 +176,7 @@ contract ForkableZkEVMTest is Test {
         batches[0] = PolygonZkEVM.BatchData({
             transactions: bytes("0x"),
             globalExitRoot: bytes32("0x"),
-            timestamp: uint64(block.timestamp),
+            timestamp: uint64(0),
             minForcedTimestamp: 0
         });
         address l2Coinbase = address(

--- a/test/ForkableZkEVM.t.sol
+++ b/test/ForkableZkEVM.t.sol
@@ -1,0 +1,189 @@
+pragma solidity ^0.8.17;
+
+import {Test} from "forge-std/Test.sol";
+import {PolygonZkEVM} from "@RealityETH/zkevm-contracts/contracts/inheritedMainContracts/PolygonZkEVM.sol";
+import {ForkableZkEVM} from "../development/contracts/ForkableZkEVM.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {IPolygonZkEVMGlobalExitRoot} from "@RealityETH/zkevm-contracts/contracts/interfaces/IPolygonZkEVMGlobalExitRoot.sol";
+import {IVerifierRollup} from "@RealityETH/zkevm-contracts/contracts/interfaces/IVerifierRollup.sol";
+import {IPolygonZkEVMBridge} from "@RealityETH/zkevm-contracts/contracts/interfaces/IPolygonZkEVMBridge.sol";
+import {IPolygonZkEVM} from "@RealityETH/zkevm-contracts/contracts/interfaces/IPolygonZkEVM.sol";
+import {IERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/interfaces/IERC20Upgradeable.sol";
+import {Util} from "./utils/Util.sol";
+
+contract ForkableZkEVMTest is Test {
+    ForkableZkEVM public forkableZkEVM;
+
+    bytes32 internal constant _IMPLEMENTATION_SLOT =
+        0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc;
+
+    address public forkmanager = address(0x123);
+    address public parentContract = address(0x456);
+    address public updater =
+        address(0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38);
+    address public forkableZkEVMImplementation;
+
+    IPolygonZkEVMGlobalExitRoot public _globalExitRootManager =
+        IPolygonZkEVMGlobalExitRoot(0x1804c8ab1f12e6BBF3894d4083f33E07309d1f39);
+    IERC20Upgradeable public _matic =
+        IERC20Upgradeable(0x1804c8ab1f12E6bbF3894d4083F33e07309d1f40);
+    IVerifierRollup public _rollupVerifier =
+        IVerifierRollup(0x1804c8ab1f12E6BBf3894d4083F33E07309d1F41);
+    IPolygonZkEVMBridge public _bridgeAddress =
+        IPolygonZkEVMBridge(0x1804c8ab1F12E6BBF3894d4083f33e07309d1f42);
+
+    bytes32 public genesisRoot = keccak256(abi.encodePacked("genesisRoot"));
+    string public _trustedSequencerURL = "http://example.com";
+    string public _networkName = "Test Network";
+    string public _version = "1.0.0";
+    uint64 public forkID = 3;
+    uint64 public chainID = 4;
+    uint32 public networkID = 10;
+    address public admin = address(0x1234567890123456789012345678901234567890);
+    uint64 public pendingStateTimeout = 123;
+    uint64 public trustedAggregatorTimeout = 124235;
+    address public trustedSequencer =
+        address(0x1234567890123456789012345678901234567899);
+    address public trustedAggregator =
+        address(0x1234567890123456789012345678901234567898);
+    IVerifierRollup public rollupVerifierMock =
+        IVerifierRollup(0x1234567890123456789012345678901234567893);
+    uint256 public arbitrationFee = 1020;
+
+    function setUp() public {
+        forkableZkEVMImplementation = address(new ForkableZkEVM());
+        forkableZkEVM = ForkableZkEVM(
+            address(new ERC1967Proxy(forkableZkEVMImplementation, ""))
+        );
+        IPolygonZkEVM.InitializePackedParameters
+            memory initializePackedParameters = IPolygonZkEVM
+                .InitializePackedParameters({
+                    admin: admin,
+                    trustedSequencer: trustedSequencer,
+                    pendingStateTimeout: pendingStateTimeout,
+                    trustedAggregator: trustedAggregator,
+                    trustedAggregatorTimeout: trustedAggregatorTimeout,
+                    chainID: chainID,
+                    forkID: forkID
+                });
+        forkableZkEVM.initialize(
+            forkmanager,
+            parentContract,
+            initializePackedParameters,
+            genesisRoot,
+            _trustedSequencerURL,
+            _networkName,
+            _version,
+            _globalExitRootManager,
+            _matic,
+            _rollupVerifier,
+            _bridgeAddress
+        );
+    }
+
+    function testInitialize() public {
+        assertEq(forkableZkEVM.forkmanager(), forkmanager);
+        assertEq(forkableZkEVM.parentContract(), parentContract);
+        assertTrue(
+            forkableZkEVM.hasRole(forkableZkEVM.UPDATER(), address(this))
+        );
+    }
+
+    function testCreateChildren() public {
+        address secondForkableZkEVMImplementation = address(
+            new ForkableZkEVM()
+        );
+
+        vm.expectRevert("Only forkManager is allowed");
+        forkableZkEVM.createChildren(secondForkableZkEVMImplementation);
+
+        vm.prank(forkableZkEVM.forkmanager());
+        (address child1, address child2) = forkableZkEVM.createChildren(
+            secondForkableZkEVMImplementation
+        );
+
+        // child1 and child2 addresses should not be zero address
+        assertTrue(child1 != address(0));
+        assertTrue(child2 != address(0));
+
+        // the implementation address of children should match the expected ones
+        assertEq(
+            Util.bytesToAddress(vm.load(address(child1), _IMPLEMENTATION_SLOT)),
+            forkableZkEVMImplementation
+        );
+        assertEq(
+            Util.bytesToAddress(vm.load(address(child2), _IMPLEMENTATION_SLOT)),
+            secondForkableZkEVMImplementation
+        );
+    }
+
+    function testNoVerifyBatchesAfterForking() public {
+        uint64 pendingStateNum = 10;
+        uint64 initNumBatch = 12;
+        uint64 finalNewBatch = 24;
+        bytes32 newLocalExitRoot = keccak256(
+            abi.encodePacked("newLocalExitRoot")
+        );
+        bytes32 newStateRoot = keccak256(abi.encodePacked("newStateRoot"));
+        bytes memory proof = abi.encodePacked("proof");
+
+        vm.prank(forkableZkEVM.forkmanager());
+        forkableZkEVM.createChildren(forkableZkEVMImplementation);
+
+        vm.expectRevert("No changes after forking");
+        forkableZkEVM.verifyBatches(
+            pendingStateNum,
+            initNumBatch,
+            finalNewBatch,
+            newLocalExitRoot,
+            newStateRoot,
+            proof
+        );
+    }
+
+    function testNoChangeOfConsolidationOfStateAfterForking() public {
+        vm.prank(forkableZkEVM.forkmanager());
+        forkableZkEVM.createChildren(forkableZkEVMImplementation);
+
+        vm.expectRevert("No changes after forking");
+        forkableZkEVM.consolidatePendingState(10);
+
+        vm.expectRevert("No changes after forking");
+        forkableZkEVM.overridePendingState(
+            10,
+            10,
+            10,
+            10,
+            bytes32("0x"),
+            bytes32("0x"),
+            ""
+        );
+
+        vm.expectRevert("No changes after forking");
+        PolygonZkEVM.BatchData[] memory batches = new PolygonZkEVM.BatchData[](
+            1
+        );
+        forkableZkEVM.sequenceBatches(batches, address(0));
+    }
+
+    function testModifierOfOverwrittenFunctionsStillActive() public {
+        // We call the overridden function in the overriding function sequenceBatches
+        // Here we test that PolygonZkEVM.sequenceBatches modifiers still are in place
+        // and work as expected.
+        PolygonZkEVM.BatchData[] memory batches = new PolygonZkEVM.BatchData[](
+            1
+        );
+        batches[0] = PolygonZkEVM.BatchData({
+            transactions: bytes("0x"),
+            globalExitRoot: bytes32("0x"),
+            timestamp: uint64(block.timestamp),
+            minForcedTimestamp: 0
+        });
+        address l2Coinbase = address(
+            0x1234567890123456789012345678901234567899
+        );
+        bytes4 selector = bytes4(keccak256("OnlyTrustedSequencer()"));
+        vm.expectRevert(selector);
+        forkableZkEVM.sequenceBatches(batches, l2Coinbase);
+    }
+}


### PR DESCRIPTION
Forkable zkevm implementation.


The only tricky thing was how to deal with the state updates.
There are 4 state updates(https://zkevm.polygon.technology/docs/protocol/state-management)
sequencer confirmation(for us unimportant)
sequenced(after the sequencer submitted payload to L1). We will not consider this for the forking process
verified(after a zk proof has been submitted)
consolidated(after a period called pendingStateTimeout - if the proof was given by someone random - or after verified by the trusted sequencer).

I decided that I want to only post consolidated stateRoots into the new forks. This gives the guarantees similar to the original implementation, but it might be that the verified state is not considered, in a forking situations, if it is not yet consolidated.

This might not give the nicest UX during forking, but since forking is not happening frequently, we should go for it, as it improves the security.