### PR TITLE
Allow to submit delayed fork proposals

### DIFF
--- a/development/contracts/ForkingManager.sol
+++ b/development/contracts/ForkingManager.sol
@@ -86,6 +86,7 @@ contract ForkingManager is IForkingManager, ForkableStructure {
         forkProposals[counter] = ForkProposal({
             disputeData: disputeData,
             proposedImplementations: newImplementations,
+            // solhint-disable-next-line not-rely-on-time
             executionTime: block.timestamp + preparationTime
         });
         proposalCounter = counter + 1;
@@ -99,6 +100,7 @@ contract ForkingManager is IForkingManager, ForkableStructure {
     function executeFork(uint256 counter) external onlyBeforeForking {
         require(
             forkProposals[counter].executionTime != 0 &&
+                // solhint-disable-next-line not-rely-on-time
                 forkProposals[counter].executionTime <= block.timestamp,
             "ForkingManager: fork not ready"
         );

--- a/development/contracts/interfaces/IForkingManager.sol
+++ b/development/contracts/interfaces/IForkingManager.sol
@@ -4,12 +4,52 @@ pragma solidity ^0.8.17;
 import {IForkableStructure} from "./IForkableStructure.sol";
 
 interface IForkingManager is IForkableStructure {
+    // Dispute contract and call to identify the dispute
+    // that will be used to initiate/justify the fork
+    struct DisputeData {
+        address disputeContract;
+        bytes disputeCall;
+    }
+
+    // Struct containing the addresses of the new implementations
+    struct NewImplementations {
+        address bridgeImplementation;
+        address zkEVMImplementation;
+        address forkonomicTokenImplementation;
+        address forkingManagerImplementation;
+        address globalExitRootImplementation;
+        address verifier;
+    }
+
+    // Struct that holds an address pair used to store the new child contracts
+    struct AddressPair {
+        address one;
+        address two;
+    }
+
+    // Struct containing the addresses of the new instances
+    struct NewInstances {
+        AddressPair forkingManager;
+        AddressPair bridge;
+        AddressPair zkEVM;
+        AddressPair forkonomicToken;
+        AddressPair globalExitRoot;
+    }
+    
+    // Struct containing the data for the paid fork
+    struct ForkProposal {
+        DisputeData disputeData;
+        NewImplementations proposedImplementations;
+        uint256 executionTime;
+    }
+
     function initialize(
         address _zkEVM,
         address _bridge,
         address _forkonomicToken,
         address _parentContract,
         address _globalExitRoot,
-        uint256 _arbitrationFee
+        uint256 _arbitrationFee,
+        ForkProposal[] memory proposals
     ) external;
 }

--- a/development/contracts/interfaces/IForkingManager.sol
+++ b/development/contracts/interfaces/IForkingManager.sol
@@ -35,7 +35,7 @@ interface IForkingManager is IForkableStructure {
         AddressPair forkonomicToken;
         AddressPair globalExitRoot;
     }
-    
+
     // Struct containing the data for the paid fork
     struct ForkProposal {
         DisputeData disputeData;


### PR DESCRIPTION
This PR allows to submit delayed/scheduled fork proposals.

I image that each adjudication framework will enforce its own delay and hence, we don't enforce a specific number.

The main concern about this implementation is that different delays might cause overlapping scheduled forks. This implementation copies the forkschedules then just to the new forking managers. This is okay, as different forks should be scheduled to remove different courts.(This could be enforced by outside non-core helper contracts at the submission time of the tx.

