### PR TITLE
Expose the forkmanager() and parentContract() methods in the interface

### DIFF
--- a/contracts/interfaces/IForkableStructure.sol
+++ b/contracts/interfaces/IForkableStructure.sol
@@ -3,5 +3,10 @@
 pragma solidity ^0.8.20;
 
 interface IForkableStructure {
+
+    function forkmanager() external view returns (address);
+
+    function parentContract() external view returns (address);
+
     function getChildren() external view returns (address, address);
 }

--- a/contracts/mixin/ForkableStructure.sol
+++ b/contracts/mixin/ForkableStructure.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.20;
 
 import {IForkableStructure} from "../interfaces/IForkableStructure.sol";
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import {ForkableStructure} from "./ForkableStructure.sol";
 import {CreateChildren} from "../lib/CreateChildren.sol";
 
 contract ForkableStructure is IForkableStructure, Initializable {


### PR DESCRIPTION
Immediate motivation is to be able to look up the `forkmanager()` of a bridge to route the fork requests to it, but it seems like these should be exposed in the interface anyhow as they're present when you inherit `ForkableStructure`.

Arguably `forkmanager` should be renamed but if we do that we'll do it in another commit.