### PR TITLE
forkId should be the same

### DIFF
--- a/contracts/ForkingManager.sol
+++ b/contracts/ForkingManager.sol
@@ -54,6 +54,7 @@ contract ForkingManager is IForkingManager, ForkableStructure {
         address forkingManagerImplementation;
         address globalExitRootImplementation;
         address verifier;
+        uint64 forkID;
     }
 
     // Struct that holds an address pair used to store the new child contracts
@@ -173,6 +174,7 @@ contract ForkingManager is IForkingManager, ForkableStructure {
             );
             initializePackedParameters.chainID = ChainIdManager(chainIdManager)
                 .getNextUsableChainId();
+            initializePackedParameters.forkID = newImplementations.forkID;
             IForkableZkEVM(newInstances.zkEVM.two).initialize(
                 newInstances.forkingManager.two,
                 zkEVM,

--- a/contracts/ForkingManager.sol
+++ b/contracts/ForkingManager.sol
@@ -156,7 +156,7 @@ contract ForkingManager is IForkingManager, ForkableStructure {
                         .trustedAggregatorTimeout(),
                     chainID: ChainIdManager(chainIdManager)
                         .getNextUsableChainId(),
-                    forkID: (IPolygonZkEVM(zkEVM).chainID() / 2) * 2 + 3
+                    forkID: IPolygonZkEVM(zkEVM).forkID()
                 });
             IForkableZkEVM(newInstances.zkEVM.one).initialize(
                 newInstances.forkingManager.one,
@@ -173,7 +173,6 @@ contract ForkingManager is IForkingManager, ForkableStructure {
             );
             initializePackedParameters.chainID = ChainIdManager(chainIdManager)
                 .getNextUsableChainId();
-            initializePackedParameters.forkID += 1;
             IForkableZkEVM(newInstances.zkEVM.two).initialize(
                 newInstances.forkingManager.two,
                 zkEVM,

--- a/test/ForkingManager.t.sol
+++ b/test/ForkingManager.t.sol
@@ -41,6 +41,7 @@ contract ForkingManagerTest is Test {
             0x827a9240c96ccb855e4943cc9bc49a50b1e91ba087007441a1ae5f9df8d1c57c
         );
     uint64 public forkID = 3;
+    uint64 public newForkID = 4;
     uint64 public chainID = 4;
     uint32 public networkID = 10;
     uint64 public pendingStateTimeout = 123;
@@ -208,7 +209,8 @@ contract ForkingManagerTest is Test {
                 forkonomicTokenImplementation: newForkonomicTokenImplementation,
                 forkingManagerImplementation: newForkmanagerImplementation,
                 globalExitRootImplementation: newGlobalExitRootImplementation,
-                verifier: newVerifierImplementation
+                verifier: newVerifierImplementation,
+                forkID: newForkID
             })
         );
 
@@ -235,7 +237,8 @@ contract ForkingManagerTest is Test {
                 forkonomicTokenImplementation: newForkonomicTokenImplementation,
                 forkingManagerImplementation: newForkmanagerImplementation,
                 globalExitRootImplementation: newGlobalExitRootImplementation,
-                verifier: newVerifierImplementation
+                verifier: newVerifierImplementation,
+                forkID: newForkID
             })
         );
     }
@@ -281,7 +284,8 @@ contract ForkingManagerTest is Test {
                 forkonomicTokenImplementation: newForkonomicTokenImplementation,
                 forkingManagerImplementation: newForkmanagerImplementation,
                 globalExitRootImplementation: newGlobalExitRootImplementation,
-                verifier: newVerifierImplementation
+                verifier: newVerifierImplementation,
+                forkID: newForkID
             })
         );
 
@@ -349,6 +353,11 @@ contract ForkingManagerTest is Test {
             );
             assertEq(ForkableZkEVM(childZkevm1).chainID(), firstChainId);
             assertEq(ForkableZkEVM(childZkevm2).chainID(), secondChainId);
+            assertEq(
+                ForkableZkEVM(childZkevm1).forkID(),
+                ForkableZkEVM(zkevm).forkID()
+            );
+            assertEq(ForkableZkEVM(childZkevm2).forkID(), newForkID);
         }
         {
             // Fetch the children from the ForkonomicToken contract


### PR DESCRIPTION
The forkId describes the "client software that should be run". Hence, the fork representing the current status quo should not run a new forkID parameter, only the other new chain. 