### PR TITLE
Delayed fork proposals

### DIFF
--- a/contracts/ForkingManager.sol
+++ b/contracts/ForkingManager.sol
@@ -37,10 +37,9 @@ contract ForkingManager is IForkingManager, ForkableStructure {
     // Fee that needs to be paid to initiate a fork
     uint256 public arbitrationFee;
 
-    // variable store the fork proposal data
     ForkProposal public forkProposal;
 
-    uint256 public immutable forkPreparationTime = 60 * 60 * 24 * 7;
+    uint256 public immutable forkPreparationTime = 1 weeks;
 
     /// @inheritdoc IForkingManager
     function initialize(
@@ -81,7 +80,6 @@ contract ForkingManager is IForkingManager, ForkableStructure {
             address(this),
             arbitrationFee
         );
-        // Store the dispute contract and call to identify the dispute
         forkProposal = ForkProposal({
             disputeData: disputeData,
             proposedImplementations: newImplementations,
@@ -231,7 +229,6 @@ contract ForkingManager is IForkingManager, ForkableStructure {
         );
 
         //Initialize the forking manager contracts
-
         IForkingManager(newInstances.forkingManager.one).initialize(
             newInstances.zkEVM.one,
             newInstances.bridge.one,

--- a/contracts/interfaces/IForkingManager.sol
+++ b/contracts/interfaces/IForkingManager.sol
@@ -4,6 +4,46 @@ pragma solidity ^0.8.20;
 import {IForkableStructure} from "./IForkableStructure.sol";
 
 interface IForkingManager is IForkableStructure {
+    // Dispute contract and call to identify the dispute
+    // that will be used to initiate/justify the fork
+    struct DisputeData {
+        address disputeContract;
+        bytes disputeCall;
+    }
+
+    // Struct containing the addresses of the new implementations
+    struct NewImplementations {
+        address bridgeImplementation;
+        address zkEVMImplementation;
+        address forkonomicTokenImplementation;
+        address forkingManagerImplementation;
+        address globalExitRootImplementation;
+        address verifier;
+        uint64 forkID;
+    }
+
+    // Struct that holds an address pair used to store the new child contracts
+    struct AddressPair {
+        address one;
+        address two;
+    }
+
+    // Struct containing the addresses of the new instances
+    struct NewInstances {
+        AddressPair forkingManager;
+        AddressPair bridge;
+        AddressPair zkEVM;
+        AddressPair forkonomicToken;
+        AddressPair globalExitRoot;
+    }
+
+    // Struct containing the data for the paid fork
+    struct ForkProposal {
+        DisputeData disputeData;
+        NewImplementations proposedImplementations;
+        uint256 executionTime;
+    }
+
     function initialize(
         address _zkEVM,
         address _bridge,

--- a/contracts/interfaces/IForkingManager.sol
+++ b/contracts/interfaces/IForkingManager.sol
@@ -37,13 +37,6 @@ interface IForkingManager is IForkableStructure {
         AddressPair globalExitRoot;
     }
 
-    // Struct containing the data for the paid fork
-    struct ForkProposal {
-        DisputeData disputeData;
-        NewImplementations proposedImplementations;
-        uint256 executionTime;
-    }
-
     function initialize(
         address _zkEVM,
         address _bridge,

--- a/test/ForkingManager.t.sol
+++ b/test/ForkingManager.t.sol
@@ -426,14 +426,15 @@ contract ForkingManagerTest is Test {
         forkmanager.executeFork();
 
         (
-            ForkingManager.DisputeData memory receivedDisputeData,
-            ,
-            uint256 receivedExecutionTime
-        ) = ForkingManager(forkmanager).forkProposal();
+            address receivedDisputeContract,
+            bytes memory receivedDisputeCall
+        ) = ForkingManager(forkmanager).disputeData();
+        uint256 receivedExecutionTime = ForkingManager(forkmanager)
+            .executionTimeForProposal();
 
         // Assert the dispute contract and call stored in the ForkingManager match the ones we provided
-        assertEq(receivedDisputeData.disputeContract, disputeContract);
-        assertEq(receivedDisputeData.disputeCall, disputeCall);
+        assertEq(receivedDisputeContract, disputeContract);
+        assertEq(receivedDisputeCall, disputeCall);
         assertEq(
             receivedExecutionTime,
             testTimestamp + forkmanager.forkPreparationTime()


### PR DESCRIPTION
This PR allows to submit delayed/scheduled fork proposals.

I image that each adjudication framework will enforce its own delay and hence, we don't enforce a specific number.

The main concern about this implementation is that different delays might cause overlapping scheduled forks. This implementation copies the forkschedules then just to the new forking managers. This is okay, as different forks should be scheduled to remove different courts.(This could be enforced by outside non-core helper contracts at the submission time of the tx.