### PR TITLE
rewrite chainIdManager

### DIFF
--- a/test/ForkingManager.t.sol
+++ b/test/ForkingManager.t.sol
@@ -57,6 +57,7 @@ contract ForkingManagerTest is Test {
     uint256 public arbitrationFee = 1020;
     bytes32[32] public depositTree;
     address public admin = address(0xad);
+    uint64 public initialChainId = 1;
     uint64 public firstChainId = 1;
     uint64 public secondChainId = 2;
 
@@ -110,10 +111,7 @@ contract ForkingManagerTest is Test {
             )
         );
 
-        chainIdManager = address(new ChainIdManager());
-
-        ChainIdManager(chainIdManager).addChainId(firstChainId);
-        ChainIdManager(chainIdManager).addChainId(secondChainId);
+        chainIdManager = address(new ChainIdManager(initialChainId));
         globalExitRoot.initialize(
             address(forkmanager),
             address(0x0),


### PR DESCRIPTION
Rewriting the chainId manger using the idea to introduce a cost to use up a chainID.

ChainIds are given out sequentially, but an owner can denylist certain chainId that are used by other projects, such that these chainIds are not handed out by the chainIdManager