### PR TITLE
Reserve chainId already during initiation of fork

### DIFF
--- a/contracts/ForkingManager.sol
+++ b/contracts/ForkingManager.sol
@@ -44,6 +44,10 @@ contract ForkingManager is IForkingManager, ForkableStructure {
     uint256 public executionTimeForProposal;
     uint256 public forkPreparationTime;
 
+    // variables to store the reserved chainIds for the forks
+    uint64 public reservedChainIdForFork1;
+    uint64 public reservedChainIdForFork2;
+
     /// @inheritdoc IForkingManager
     function initialize(
         address _zkEVM,
@@ -103,6 +107,10 @@ contract ForkingManager is IForkingManager, ForkableStructure {
             "Invalid new implementations"
         );
         proposedImplementations = _newImplementations;
+        reservedChainIdForFork1 = ChainIdManager(chainIdManager)
+            .getNextUsableChainId();
+        reservedChainIdForFork2 = ChainIdManager(chainIdManager)
+            .getNextUsableChainId();
         // solhint-disable-next-line not-rely-on-time
         executionTimeForProposal = (block.timestamp + forkPreparationTime);
     }
@@ -214,8 +222,7 @@ contract ForkingManager is IForkingManager, ForkableStructure {
                     trustedAggregator: IPolygonZkEVM(zkEVM).trustedAggregator(),
                     trustedAggregatorTimeout: IPolygonZkEVM(zkEVM)
                         .trustedAggregatorTimeout(),
-                    chainID: ChainIdManager(chainIdManager)
-                        .getNextUsableChainId(),
+                    chainID: reservedChainIdForFork1,
                     forkID: IPolygonZkEVM(zkEVM).forkID()
                 });
             IForkableZkEVM(newInstances.zkEVM.one).initialize(
@@ -326,8 +333,7 @@ contract ForkingManager is IForkingManager, ForkableStructure {
                     trustedAggregator: IPolygonZkEVM(zkEVM).trustedAggregator(),
                     trustedAggregatorTimeout: IPolygonZkEVM(zkEVM)
                         .trustedAggregatorTimeout(),
-                    chainID: ChainIdManager(chainIdManager)
-                        .getNextUsableChainId(),
+                    chainID: reservedChainIdForFork2,
                     forkID: newImplementations.forkID > 0
                         ? newImplementations.forkID
                         : IPolygonZkEVM(zkEVM).forkID()

--- a/test/ForkingManager.t.sol
+++ b/test/ForkingManager.t.sol
@@ -650,7 +650,9 @@ contract ForkingManagerTest is Test {
         }
     }
 
-    function testInitiateForkSetsDispuateDataAndExecutionTimeAndReservesChainIds() public {
+    function testInitiateForkSetsDisputeDataAndExecutionTimeAndReservesChainIds()
+        public
+    {
         // Mint and approve the arbitration fee for the test contract
         forkonomicToken.approve(address(forkmanager), arbitrationFee);
         vm.prank(address(this));
@@ -692,9 +694,11 @@ contract ForkingManagerTest is Test {
             testTimestamp + forkmanager.forkPreparationTime()
         );
 
-        uint64 reservedChainIdForFork1 = ForkingManager(forkmanager).reservedChainIdForFork1();
+        uint64 reservedChainIdForFork1 = ForkingManager(forkmanager)
+            .reservedChainIdForFork1();
         assertEq(reservedChainIdForFork1, firstChainId);
-        uint64 reservedChainIdForFork2 = ForkingManager(forkmanager).reservedChainIdForFork2();
+        uint64 reservedChainIdForFork2 = ForkingManager(forkmanager)
+            .reservedChainIdForFork2();
         assertEq(reservedChainIdForFork2, secondChainId);
     }
 

--- a/test/ForkingManager.t.sol
+++ b/test/ForkingManager.t.sol
@@ -650,7 +650,7 @@ contract ForkingManagerTest is Test {
         }
     }
 
-    function testInitiateForkSetsDispuateDataAndExecutionTime() public {
+    function testInitiateForkSetsDispuateDataAndExecutionTimeAndReservesChainIds() public {
         // Mint and approve the arbitration fee for the test contract
         forkonomicToken.approve(address(forkmanager), arbitrationFee);
         vm.prank(address(this));
@@ -691,6 +691,11 @@ contract ForkingManagerTest is Test {
             receivedExecutionTime,
             testTimestamp + forkmanager.forkPreparationTime()
         );
+
+        uint64 reservedChainIdForFork1 = ForkingManager(forkmanager).reservedChainIdForFork1();
+        assertEq(reservedChainIdForFork1, firstChainId);
+        uint64 reservedChainIdForFork2 = ForkingManager(forkmanager).reservedChainIdForFork2();
+        assertEq(reservedChainIdForFork2, secondChainId);
     }
 
     function testExecuteForkRespectsTime() public {


### PR DESCRIPTION
It's better if we know the chainId already before, and not just in the moment of the creation of the forks