### PR TITLE
No upgrades via forks

### DIFF
--- a/contracts/ForkableBridge.sol
+++ b/contracts/ForkableBridge.sol
@@ -99,12 +99,14 @@ contract ForkableBridge is
     }
 
     // @inheritdoc IForkableBridge
-    function createChildren(
-        address implementation
-    ) external onlyForkManger returns (address, address) {
+    function createChildren()
+        external
+        onlyForkManger
+        returns (address, address)
+    {
         // process all pending deposits/messages before coping over the state root.
         updateGlobalExitRoot();
-        return _createChildren(implementation);
+        return _createChildren();
     }
 
     // @inheritdoc IForkableBridge

--- a/contracts/ForkableGlobalExitRoot.sol
+++ b/contracts/ForkableGlobalExitRoot.sol
@@ -32,11 +32,12 @@ contract ForkableGlobalExitRoot is
     }
 
     /// @dev Public interface to create children. This can only be done by the forkmanager
-    /// @param implementation Allows to pass a different implementation contract for the second proxied child.
     /// @return The addresses of the two children
-    function createChildren(
-        address implementation
-    ) external onlyForkManger returns (address, address) {
-        return _createChildren(implementation);
+    function createChildren()
+        external
+        onlyForkManger
+        returns (address, address)
+    {
+        return _createChildren();
     }
 }

--- a/contracts/ForkableZkEVM.sol
+++ b/contracts/ForkableZkEVM.sol
@@ -41,10 +41,12 @@ contract ForkableZkEVM is ForkableStructure, IForkableZkEVM, PolygonZkEVM {
     }
 
     // @inheritdoc IForkableZkEVM
-    function createChildren(
-        address implementation
-    ) external onlyForkManger returns (address, address) {
-        return _createChildren(implementation);
+    function createChildren()
+        external
+        onlyForkManger
+        returns (address, address)
+    {
+        return _createChildren();
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/contracts/ForkonomicToken.sol
+++ b/contracts/ForkonomicToken.sol
@@ -46,10 +46,12 @@ contract ForkonomicToken is
     }
 
     /// @inheritdoc IForkonomicToken
-    function createChildren(
-        address implementation
-    ) external onlyForkManger returns (address, address) {
-        return _createChildren(implementation);
+    function createChildren()
+        external
+        onlyForkManger
+        returns (address, address)
+    {
+        return _createChildren();
     }
 
     function splitTokenAndMintOneChild(

--- a/contracts/L1GlobalForkRequester.sol
+++ b/contracts/L1GlobalForkRequester.sol
@@ -97,10 +97,9 @@ contract L1GlobalForkRequester {
             );
 
             // Assume the data contains the questionId and pass it directly to the forkmanager in the fork request
-            IForkingManager.NewImplementations memory newImplementations;
             IForkingManager.DisputeData memory disputeData = IForkingManager
                 .DisputeData(false, beneficiary, requestId);
-            forkingManager.initiateFork(disputeData, newImplementations);
+            forkingManager.initiateFork(disputeData);
         } else {
             // Store the request so we can return the tokens across the bridge
             // If the fork has already happened we may have to split them first and do this twice.

--- a/contracts/interfaces/IForkableBridge.sol
+++ b/contracts/interfaces/IForkableBridge.sol
@@ -39,11 +39,8 @@ interface IForkableBridge is IForkableStructure, IPolygonZkEVMBridge {
 
     /**
      * @dev Function to create the children contracts
-     * @param implementation: address of the implementation contract
      */
-    function createChildren(
-        address implementation
-    ) external returns (address, address);
+    function createChildren() external returns (address, address);
 
     /**
      * @dev Anyone can use their tokens to split the bridged tokens into the two corresponding children tokens

--- a/contracts/interfaces/IForkableGlobalExitRoot.sol
+++ b/contracts/interfaces/IForkableGlobalExitRoot.sol
@@ -24,7 +24,8 @@ interface IForkableGlobalExitRoot is
         bytes32 _lastRollupExitRoot
     ) external;
 
-    function createChildren(
-        address implementation
-    ) external returns (address, address);
+    /**
+     * @dev Function to create the children contracts
+     */
+    function createChildren() external returns (address, address);
 }

--- a/contracts/interfaces/IForkableZkEVM.sol
+++ b/contracts/interfaces/IForkableZkEVM.sol
@@ -39,7 +39,5 @@ interface IForkableZkEVM is IForkableStructure, IPolygonZkEVM {
     // The initialization of the children contracts should be called in the same transaction
     // as the creation of the children contracts.
     // @params implemation: The implementation of the children contracts.
-    function createChildren(
-        address implementation
-    ) external returns (address, address);
+    function createChildren() external returns (address, address);
 }

--- a/contracts/interfaces/IForkingManager.sol
+++ b/contracts/interfaces/IForkingManager.sol
@@ -82,8 +82,5 @@ interface IForkingManager is IForkableStructure {
         uint256 _forkPreparationTime
     ) external;
 
-    function initiateFork(
-        DisputeData memory _disputeData,
-        NewImplementations calldata newImplementations
-    ) external;
+    function initiateFork(DisputeData memory _disputeData) external;
 }

--- a/contracts/interfaces/IForkonomicToken.sol
+++ b/contracts/interfaces/IForkonomicToken.sol
@@ -25,11 +25,8 @@ interface IForkonomicToken is IForkableStructure, IERC20Upgradeable {
     function mint(address to, uint256 amount) external;
 
     /// @dev Interface for the forkManger to create children
-    /// @param implementation Allows to pass a different implementation contract for the second proxied child.
     /// @return The addresses of the two children
-    function createChildren(
-        address implementation
-    ) external returns (address, address);
+    function createChildren() external returns (address, address);
 
     /// @dev Allows anyone to split the tokens from the parent contract into the tokens of the children
     /// @param amount The amount of tokens to split

--- a/contracts/lib/CreateChildren.sol
+++ b/contracts/lib/CreateChildren.sol
@@ -16,7 +16,7 @@ library CreateChildren {
     /**
      * @dev Returns the current implementation address.
      */
-    function _getImplementation() internal view returns (address) {
+    function getImplementation() internal view returns (address) {
         return StorageSlot.getAddressSlot(_IMPLEMENTATION_SLOT).value;
     }
 
@@ -31,45 +31,19 @@ library CreateChildren {
     /**
      * @dev Returns the current admin.
      */
-    function _getAdmin() internal view returns (address) {
+    function getAdmin() internal view returns (address) {
         return StorageSlot.getAddressSlot(_ADMIN_SLOT).value;
     }
 
     /// @dev Internal function to create the children contracts.
-    function createChild1() public returns (address forkingManager1) {
-        // Fork 1 will always keep the original implementation
-        forkingManager1 = address(
-            new TransparentUpgradeableProxy(
-                _getImplementation(),
-                _getAdmin(),
-                ""
-            )
+    function createChildren() public returns (address child1, address child2) {
+        address implementation = getImplementation();
+        address admin = getAdmin();
+        child1 = address(
+            new TransparentUpgradeableProxy(implementation, admin, "")
         );
-    }
-
-    /// @dev Internal function to create the child 2
-    ///
-    /// @param implementation Allows to pass a different implementation contract for the second proxied child.
-    function createChild2(
-        address implementation
-    ) public returns (address forkingManager2) {
-        if (address(implementation) == address(0)) {
-            implementation = _getImplementation();
-        }
-        // Fork 2 can introduce a new implementation, if a different implementation contract
-        // is passed in
-        forkingManager2 = address(
-            new TransparentUpgradeableProxy(implementation, _getAdmin(), "")
+        child2 = address(
+            new TransparentUpgradeableProxy(implementation, admin, "")
         );
-    }
-
-    /// @dev Internal function to create the children contracts.
-    ///
-    /// @param implementation Allows to pass a different implementation contract for the second proxied child.
-    function createChildren(
-        address implementation
-    ) public returns (address forkingManager1, address forkingManager2) {
-        forkingManager1 = createChild1();
-        forkingManager2 = createChild2(implementation);
     }
 }

--- a/contracts/mixin/ForkableStructure.sol
+++ b/contracts/mixin/ForkableStructure.sol
@@ -58,15 +58,14 @@ contract ForkableStructure is IForkableStructure, Initializable {
 
     /**
      *  @dev Internal function to create the children contracts.
-     * @param implementation Allows to pass a different implementation contract for the second proxied child.
      */
-    function _createChildren(
-        address implementation
-    ) internal returns (address forkingManager1, address forkingManager2) {
-        forkingManager1 = CreateChildren.createChild1();
-        children[0] = forkingManager1;
-        forkingManager2 = CreateChildren.createChild2(implementation);
-        children[1] = forkingManager2;
+    function _createChildren()
+        internal
+        returns (address child0, address child1)
+    {
+        (child0, child1) = CreateChildren.createChildren();
+        children[0] = child0;
+        children[1] = child1;
     }
 
     function getChildren() public view returns (address, address) {

--- a/test/ForkableBridge.t.sol
+++ b/test/ForkableBridge.t.sol
@@ -69,11 +69,8 @@ contract ForkableBridgeTest is Test {
     }
 
     function testCreateChildren() public {
-        address secondBridgeImplementation = address(
-            new ForkableBridgeWrapper()
-        );
         vm.expectRevert(bytes("Not forkManager"));
-        forkableBridge.createChildren(secondBridgeImplementation);
+        forkableBridge.createChildren();
         ForkableGlobalExitRoot exitRoot = new ForkableGlobalExitRoot();
         vm.mockCall(
             address(_globalExitRootManager),
@@ -85,9 +82,7 @@ contract ForkableBridgeTest is Test {
         );
 
         vm.prank(forkableBridge.forkmanager());
-        (address child1, address child2) = forkableBridge.createChildren(
-            secondBridgeImplementation
-        );
+        (address child1, address child2) = forkableBridge.createChildren();
         assertTrue(child1 != address(0));
         assertTrue(child2 != address(0));
     }
@@ -221,13 +216,8 @@ contract ForkableBridgeTest is Test {
         vm.expectRevert(bytes("onlyAfterForking"));
         forkableBridge.splitTokenIntoChildToken(address(token), amount, true);
 
-        address secondBridgeImplementation = address(
-            new ForkableBridgeWrapper()
-        );
         vm.prank(forkableBridge.forkmanager());
-        (address child1, address child2) = forkableBridge.createChildren(
-            secondBridgeImplementation
-        );
+        (address child1, address child2) = forkableBridge.createChildren();
 
         // Create forkable token
         vm.prank(forkableBridge.parentContract());
@@ -306,13 +296,8 @@ contract ForkableBridgeTest is Test {
             abi.encodePacked(originNetwork, token)
         );
 
-        address secondBridgeImplementation = address(
-            new ForkableBridgeWrapper()
-        );
         vm.prank(forkableBridge.forkmanager());
-        (address child1, address child2) = forkableBridge.createChildren(
-            secondBridgeImplementation
-        );
+        (address child1, address child2) = forkableBridge.createChildren();
 
         // Create forkable token
         vm.prank(forkableBridge.parentContract());
@@ -389,7 +374,6 @@ contract ForkableBridgeTest is Test {
     }
 
     function testNoDepostOrClaimingAfterForking() public {
-        address secondBridgeImplementation = address(new ForkableBridge());
         ForkableGlobalExitRoot exitRoot = new ForkableGlobalExitRoot();
         vm.mockCall(
             address(_globalExitRootManager),
@@ -401,7 +385,7 @@ contract ForkableBridgeTest is Test {
         );
 
         vm.prank(forkableBridge.forkmanager());
-        forkableBridge.createChildren(secondBridgeImplementation);
+        forkableBridge.createChildren();
 
         vm.expectRevert(bytes("No changes after forking"));
         forkableBridge.bridgeAsset(
@@ -471,9 +455,6 @@ contract ForkableBridgeTest is Test {
             to
         );
 
-        address secondBridgeImplementation = address(
-            new ForkableBridgeWrapper()
-        );
         ForkableGlobalExitRoot exitRoot = new ForkableGlobalExitRoot();
         vm.mockCall(
             address(_globalExitRootManager),
@@ -484,9 +465,7 @@ contract ForkableBridgeTest is Test {
             ""
         );
         vm.prank(forkableBridge.forkmanager());
-        (address child1, address child2) = forkableBridge.createChildren(
-            secondBridgeImplementation
-        );
+        (address child1, address child2) = forkableBridge.createChildren();
 
         // initialize the child contracts to set the parent contract
         ForkableBridge(child1).initialize(
@@ -590,9 +569,6 @@ contract ForkableBridgeTest is Test {
         forkableBridge2.sendForkonomicTokensToChild(10, true, false);
 
         // Create initiate the forking process and create children
-        address secondBridgeImplementation = address(
-            new ForkableBridgeWrapper()
-        );
         ForkableGlobalExitRoot exitRoot = new ForkableGlobalExitRoot();
         vm.mockCall(
             address(_globalExitRootManager),
@@ -603,9 +579,7 @@ contract ForkableBridgeTest is Test {
             ""
         );
         vm.prank(forkableBridge2.forkmanager());
-        (address child1, address child2) = forkableBridge2.createChildren(
-            secondBridgeImplementation
-        );
+        (address child1, address child2) = forkableBridge2.createChildren();
 
         // The initial balances
         uint256 initialBridgeBalance = erc20GasToken.balanceOf(
@@ -619,7 +593,7 @@ contract ForkableBridgeTest is Test {
 
         vm.prank(forkmanager);
         (address forkonomicToken1, address forkonomicToken2) = erc20GasToken
-            .createChildren(forkonomicTokenImplementation);
+            .createChildren();
         ForkonomicToken(forkonomicToken1).initialize(
             forkmanager,
             address(this),
@@ -692,10 +666,6 @@ contract ForkableBridgeWrapperTest is Test {
 
     function testIsClaimedOnParent() public {
         uint256 index = 1;
-
-        address secondBridgeImplementation = address(
-            new ForkableBridgeWrapper()
-        );
         ForkableGlobalExitRoot exitRoot = new ForkableGlobalExitRoot();
         vm.mockCall(
             address(_globalExitRootManager),
@@ -706,9 +676,7 @@ contract ForkableBridgeWrapperTest is Test {
             ""
         );
         vm.prank(forkableBridge.forkmanager());
-        (address child1, address child2) = forkableBridge.createChildren(
-            secondBridgeImplementation
-        );
+        (address child1, address child2) = forkableBridge.createChildren();
 
         // initialize the child contracts to set the parent contract
         ForkableBridge(child1).initialize(
@@ -754,9 +722,6 @@ contract ForkableBridgeWrapperTest is Test {
     function testIsClaimedOnParentIsConsideringLastDepositUpdate() public {
         uint256 index = 1;
 
-        address secondBridgeImplementation = address(
-            new ForkableBridgeWrapper()
-        );
         ForkableGlobalExitRoot exitRoot = new ForkableGlobalExitRoot();
         vm.mockCall(
             address(_globalExitRootManager),
@@ -767,9 +732,7 @@ contract ForkableBridgeWrapperTest is Test {
             ""
         );
         vm.prank(forkableBridge.forkmanager());
-        (address child1, address child2) = forkableBridge.createChildren(
-            secondBridgeImplementation
-        );
+        (address child1, address child2) = forkableBridge.createChildren();
 
         // initialize the child contracts to set the parent contract
         ForkableBridgeWrapper(child1).initialize(
@@ -820,10 +783,6 @@ contract ForkableBridgeWrapperTest is Test {
 
     function testSetAndCheckClaimed() public {
         uint256 index = 1;
-
-        address secondBridgeImplementation = address(
-            new ForkableBridgeWrapper()
-        );
         ForkableGlobalExitRoot exitRoot = new ForkableGlobalExitRoot();
         vm.mockCall(
             address(_globalExitRootManager),
@@ -834,9 +793,7 @@ contract ForkableBridgeWrapperTest is Test {
             ""
         );
         vm.prank(forkableBridge.forkmanager());
-        (address child1, address child2) = forkableBridge.createChildren(
-            secondBridgeImplementation
-        );
+        (address child1, address child2) = forkableBridge.createChildren();
 
         // initialize the child contracts to set the parent contract
         ForkableBridge(child1).initialize(

--- a/test/ForkableGlobalExitRoot.t.sol
+++ b/test/ForkableGlobalExitRoot.t.sol
@@ -49,12 +49,9 @@ contract ForkableGlobalExitRootTest is Test {
     }
 
     function testCreateChildren() public {
-        address secondForkableGlobalExitRootImplementation = address(
-            new ForkableGlobalExitRoot()
-        );
         vm.prank(forkableGlobalExitRoot.forkmanager());
         (address child1, address child2) = forkableGlobalExitRoot
-            .createChildren(secondForkableGlobalExitRootImplementation);
+            .createChildren();
 
         // child1 and child2 addresses should not be zero address
         assertTrue(child1 != address(0));
@@ -67,22 +64,14 @@ contract ForkableGlobalExitRootTest is Test {
         );
         assertEq(
             Util.bytesToAddress(vm.load(address(child2), _IMPLEMENTATION_SLOT)),
-            secondForkableGlobalExitRootImplementation
+            forkableGlobalExitRootImplementation
         );
     }
 
     function testCreateChildrenOnlyByForkManager() public {
-        address secondForkableGlobalExitRootImplementation = address(
-            new ForkableGlobalExitRoot()
-        );
-
         vm.expectRevert("Not forkManager");
-        forkableGlobalExitRoot.createChildren(
-            secondForkableGlobalExitRootImplementation
-        );
+        forkableGlobalExitRoot.createChildren();
         vm.prank(forkableGlobalExitRoot.forkmanager());
-        forkableGlobalExitRoot.createChildren(
-            secondForkableGlobalExitRootImplementation
-        );
+        forkableGlobalExitRoot.createChildren();
     }
 }

--- a/test/ForkableStructure.t.sol
+++ b/test/ForkableStructure.t.sol
@@ -56,13 +56,8 @@ contract ForkStructureTest is Test {
             )
         );
         forkStructure.initialize(forkmanager, parentContract);
-        address secondForkableStructureImplementation = address(
-            new ForkableStructureWrapper()
-        );
 
-        (address child1, address child2) = forkStructure.createChildren(
-            secondForkableStructureImplementation
-        );
+        (address child1, address child2) = forkStructure.createChildren();
 
         // child1 and child2 addresses should not be zero address
         assertTrue(child1 != address(0));
@@ -75,7 +70,7 @@ contract ForkStructureTest is Test {
         );
         assertEq(
             Util.bytesToAddress(vm.load(address(child2), _IMPLEMENTATION_SLOT)),
-            secondForkableStructureImplementation
+            forkableStructureImplementation
         );
         assertEq(
             Util.bytesToAddress(vm.load(address(child1), _ADMIN_SLOT)),

--- a/test/ForkableZkEVM.t.sol
+++ b/test/ForkableZkEVM.t.sol
@@ -93,17 +93,11 @@ contract ForkableZkEVMTest is Test {
     }
 
     function testCreateChildren() public {
-        address secondForkableZkEVMImplementation = address(
-            new ForkableZkEVM()
-        );
-
         vm.expectRevert("Not forkManager");
-        forkableZkEVM.createChildren(secondForkableZkEVMImplementation);
+        forkableZkEVM.createChildren();
 
         vm.prank(forkableZkEVM.forkmanager());
-        (address child1, address child2) = forkableZkEVM.createChildren(
-            secondForkableZkEVMImplementation
-        );
+        (address child1, address child2) = forkableZkEVM.createChildren();
 
         // child1 and child2 addresses should not be zero address
         assertTrue(child1 != address(0));
@@ -116,7 +110,7 @@ contract ForkableZkEVMTest is Test {
         );
         assertEq(
             Util.bytesToAddress(vm.load(address(child2), _IMPLEMENTATION_SLOT)),
-            secondForkableZkEVMImplementation
+            forkableZkEVMImplementation
         );
     }
 
@@ -134,7 +128,7 @@ contract ForkableZkEVMTest is Test {
         }
 
         vm.prank(forkableZkEVM.forkmanager());
-        forkableZkEVM.createChildren(forkableZkEVMImplementation);
+        forkableZkEVM.createChildren();
 
         vm.expectRevert("No changes after forking");
         forkableZkEVM.verifyBatches(
@@ -149,7 +143,7 @@ contract ForkableZkEVMTest is Test {
 
     function testNoChangeOfConsolidationOfStateAfterForking() public {
         vm.prank(forkableZkEVM.forkmanager());
-        forkableZkEVM.createChildren(forkableZkEVMImplementation);
+        forkableZkEVM.createChildren();
 
         vm.expectRevert("No changes after forking");
         forkableZkEVM.consolidatePendingState(10);

--- a/test/ForkonomicToken.t.sol
+++ b/test/ForkonomicToken.t.sol
@@ -62,11 +62,8 @@ contract ForkonomicTokenTest is Test {
     }
 
     function testCreateChildrenAndSplitTokens() public {
-        address forkonomicTokenImplementation2 = address(new ForkonomicToken());
         vm.prank(forkonomicToken.forkmanager());
-        (address child1, address child2) = forkonomicToken.createChildren(
-            forkonomicTokenImplementation2
-        );
+        (address child1, address child2) = forkonomicToken.createChildren();
         ForkonomicToken(child1).initialize(
             forkmanager,
             address(forkonomicToken),

--- a/test/L1GlobalChainInfoPublisher.t.sol
+++ b/test/L1GlobalChainInfoPublisher.t.sol
@@ -285,21 +285,9 @@ contract L1GlobalChainInfoPublisherTest is Test {
         forkonomicToken.mint(address(this), arbitrationFee * 3);
 
         // Call the initiateFork function to create a new fork
-        forkmanager.initiateFork(
-            disputeData,
-            IForkingManager.NewImplementations({
-                bridgeImplementation: newBridgeImplementation,
-                zkEVMImplementation: newZkevmImplementation,
-                forkonomicTokenImplementation: newForkonomicTokenImplementation,
-                forkingManagerImplementation: newForkmanagerImplementation,
-                globalExitRootImplementation: newGlobalExitRootImplementation,
-                verifier: newVerifierImplementation,
-                forkID: newForkID
-            })
-        );
+        forkmanager.initiateFork(disputeData);
         skip(forkmanager.forkPreparationTime() + 1);
-        forkmanager.executeFork1();
-        forkmanager.executeFork2();
+        forkmanager.executeFork();
 
         // The current bridge should no longer work
         vm.expectRevert("No changes after forking");
@@ -355,17 +343,14 @@ contract L1GlobalChainInfoPublisherTest is Test {
                 isL1: true
             });
 
-        IForkingManager.NewImplementations memory newImplementations2; // Empty one to simulate a question
-
         forkonomicToken.splitTokensIntoChildTokens(arbitrationFee);
         forkonomicToken2.approve(address(forkmanager2), arbitrationFee);
         vm.prank(address(this));
 
         // Call the initiateFork function to create a new fork
-        forkmanager2.initiateFork(disputeData2, newImplementations2);
+        forkmanager2.initiateFork(disputeData2);
         skip(forkmanager.forkPreparationTime() + 1);
-        forkmanager2.executeFork1();
-        forkmanager2.executeFork2();
+        forkmanager2.executeFork();
 
         vm.expectRevert("No changes after forking");
         l1GlobalChainInfoPublisher.updateL2ChainInfo(

--- a/test/L1GlobalForkRequester.t.sol
+++ b/test/L1GlobalForkRequester.t.sol
@@ -325,19 +325,9 @@ contract L1GlobalForkRequesterTest is Test {
             vm.prank(address(this));
             forkonomicToken.approve(address(forkmanager), fee);
             // Assume the data contains the questionId and pass it directly to the forkmanager in the fork request
-            IForkingManager.NewImplementations
-                memory newImplementations = IForkingManager.NewImplementations(
-                    newBridgeImplementation,
-                    newZkevmImplementation,
-                    newForkonomicTokenImplementation,
-                    newForkmanagerImplementation,
-                    newGlobalExitRootImplementation,
-                    newVerifierImplementation,
-                    uint64(0x7)
-                );
             IForkingManager.DisputeData memory disputeData = IForkingManager
                 .DisputeData(false, address(this), requestId);
-            forkmanager.initiateFork(disputeData, newImplementations);
+            forkmanager.initiateFork(disputeData);
         }
 
         // Our handlePayment will fail and leave our money sitting in failedRequests
@@ -377,8 +367,7 @@ contract L1GlobalForkRequesterTest is Test {
 
         // Execute the other guy's fork
         skip(forkmanager.forkPreparationTime() + 1);
-        forkmanager.executeFork1();
-        forkmanager.executeFork2();
+        forkmanager.executeFork();
 
         {
             uint256 balBeforeSplit = forkonomicToken.balanceOf(

--- a/test/testcontract/ForkableStructureWrapper.sol
+++ b/test/testcontract/ForkableStructureWrapper.sol
@@ -10,10 +10,8 @@ contract ForkableStructureWrapper is ForkableStructure {
         ForkableStructure.initialize(_forkmanager, _parentContract);
     }
 
-    function createChildren(
-        address implementation
-    ) public returns (address, address) {
-        return ForkableStructure._createChildren(implementation);
+    function createChildren() public returns (address, address) {
+        return ForkableStructure._createChildren();
     }
 
     function setChild(uint256 index, address child) public {


### PR DESCRIPTION
No longer allow for new implementation during forking. These will be introduced by the security concil only if the community agrees. If there is a conflict on whether upgrades should be introduced, the chain can first split into two and then the council can do the upgrade on one chain only.

I really like this PR, since it makes our code simpler.

closes #136 
closes #76