### PR TITLE
remove can fork

### DIFF
--- a/contracts/ForkingManager.sol
+++ b/contracts/ForkingManager.sol
@@ -78,11 +78,6 @@ contract ForkingManager is IForkingManager, ForkableStructure {
         return (children[0] != address(0) || children[1] != address(0));
     }
 
-    // TODO: If there is any other reason a fork can be prevented, eg the contract can be frozen by governance, add it here.
-    function canFork() external view returns (bool) {
-        return (executionTimeForProposal == 0);
-    }
-
     /**
      * @notice function to initiate and schedule the fork
      * @param _disputeData the dispute contract and call to identify the dispute

--- a/contracts/L1GlobalForkRequester.sol
+++ b/contracts/L1GlobalForkRequester.sol
@@ -82,7 +82,7 @@ contract L1GlobalForkRequester {
         if (transferredBalance < forkingManager.arbitrationFee()) {
             isForkGuaranteedNotToRevert = false;
         }
-        if (!forkingManager.canFork()) {
+        if (forkingManager.isForkingInitiated()) {
             isForkGuaranteedNotToRevert = false;
         }
 

--- a/contracts/interfaces/IForkingManager.sol
+++ b/contracts/interfaces/IForkingManager.sol
@@ -43,8 +43,6 @@ interface IForkingManager is IForkableStructure {
 
     function isForkingExecuted() external returns (bool);
 
-    function canFork() external returns (bool);
-
     // Struct that holds an address pair used to store the new child contracts
     struct AddressPair {
         address one;

--- a/test/ForkingManager.t.sol
+++ b/test/ForkingManager.t.sol
@@ -202,7 +202,6 @@ contract ForkingManagerTest is Test {
     function testForkingStatusFunctions() public {
         assertFalse(forkmanager.isForkingInitiated());
         assertFalse(forkmanager.isForkingExecuted());
-        assertTrue(forkmanager.canFork());
 
         // Mint and approve the arbitration fee for the test contract
         forkonomicToken.approve(address(forkmanager), arbitrationFee);
@@ -226,14 +225,12 @@ contract ForkingManagerTest is Test {
 
         assertTrue(forkmanager.isForkingInitiated());
         assertFalse(forkmanager.isForkingExecuted());
-        assertFalse(forkmanager.canFork());
 
         vm.warp(block.timestamp + forkmanager.forkPreparationTime() + 1);
         forkmanager.executeFork();
 
         assertTrue(forkmanager.isForkingInitiated());
         assertTrue(forkmanager.isForkingExecuted());
-        assertFalse(forkmanager.canFork());
     }
 
     function testInitiateForkChargesFees() public {

--- a/test/L1GlobalForkRequester.t.sol
+++ b/test/L1GlobalForkRequester.t.sol
@@ -229,7 +229,6 @@ contract L1GlobalForkRequesterTest is Test {
             address(forkmanager.forkonomicToken()),
             address(forkonomicToken)
         );
-        assertTrue(forkmanager.canFork());
         assertFalse(forkmanager.isForkingInitiated());
         assertFalse(forkmanager.isForkingExecuted());
 
@@ -268,7 +267,7 @@ contract L1GlobalForkRequesterTest is Test {
             address(forkmanager.forkonomicToken()),
             address(forkonomicToken)
         );
-        assertTrue(forkmanager.canFork());
+        assertFalse(forkmanager.isForkingInitiated());
 
         l1GlobalForkRequester.handlePayment(
             address(forkonomicToken),
@@ -316,7 +315,7 @@ contract L1GlobalForkRequesterTest is Test {
             address(forkmanager.forkonomicToken()),
             address(forkonomicToken)
         );
-        assertTrue(forkmanager.canFork());
+        assertFalse(forkmanager.isForkingInitiated());
 
         {
             // Someone else starts and executes a fork before we can handle our payment


### PR DESCRIPTION
Remove the function can fork, as it coincides with existing functions in the current implementation. If it later no longer coincides, we can readded it.