### PR TITLE
Do not allow gasTokens to be managed by hard asset manager

### DIFF
--- a/contracts/ForkableBridge.sol
+++ b/contracts/ForkableBridge.sol
@@ -62,7 +62,7 @@ contract ForkableBridge is
         if (to != children[0] && to != children[1]) {
             revert InvalidDestinationForHardAsset();
         }
-        if(token==gasTokenAddress){
+        if (token == gasTokenAddress) {
             revert GasTokenIsNotHardAsset();
         }
         IERC20(token).transfer(to, amount);

--- a/contracts/ForkableBridge.sol
+++ b/contracts/ForkableBridge.sol
@@ -62,6 +62,9 @@ contract ForkableBridge is
         if (to != children[0] && to != children[1]) {
             revert InvalidDestinationForHardAsset();
         }
+        if(token==gasTokenAddress){
+            revert GasTokenIsNotHardAsset();
+        }
         IERC20(token).transfer(to, amount);
     }
 
@@ -178,8 +181,12 @@ contract ForkableBridge is
      * @dev Allows aynone to take out their forkonomic tokens
      * and send them to the children-bridge contracts
      * Notice that forkonomic tokens are special, as they their main contract
-     * is on L1, but they are still forkable tokens as all the tokens from
+     * is on L1, but they are still forkable tokens, as their contract is forked as well.
+     * We allow to send tokens only to one child, just in case the one child contract
+     * was updated shortly after the fork and contains an error (e.g. reverts on sending)
+     * @param amount Amount of tokens to be sent to the children-bridge contracts
      * @param useFirstChild boolean indicating for which child the operation should be run
+     * @param useChildTokenAllowance boolean indicating if the child token allowance (previously burned tokens) should be used
      */
     function sendForkonomicTokensToChild(
         uint256 amount,

--- a/contracts/interfaces/IForkableBridge.sol
+++ b/contracts/interfaces/IForkableBridge.sol
@@ -11,6 +11,8 @@ interface IForkableBridge is IForkableStructure, IPolygonZkEVMBridge {
     error NotAuthorized();
     /// @dev Error thrown when trying to send bridged tokens to a child contract
     error InvalidDestinationForHardAsset();
+    /// @dev Error thrown when hardasset manager tries to send gas token to a child contract
+    error GasTokenIsNotHardAsset();
 
     /**
      * @dev Function to initialize the contract

--- a/test/ForkableBridge.t.sol
+++ b/test/ForkableBridge.t.sol
@@ -505,6 +505,15 @@ contract ForkableBridgeTest is Test {
         );
 
         vm.expectRevert(
+            IForkableBridge.GasTokenIsNotHardAsset.selector
+        );
+        vm.prank(hardAssetManger);
+        forkableBridge.transferHardAssetsToChild(
+            address(gasTokenAddress),
+            amount,
+            child2
+        );
+        vm.expectRevert(
             IForkableBridge.InvalidDestinationForHardAsset.selector
         );
         vm.prank(hardAssetManger);

--- a/test/ForkableBridge.t.sol
+++ b/test/ForkableBridge.t.sol
@@ -504,9 +504,7 @@ contract ForkableBridgeTest is Test {
             to
         );
 
-        vm.expectRevert(
-            IForkableBridge.GasTokenIsNotHardAsset.selector
-        );
+        vm.expectRevert(IForkableBridge.GasTokenIsNotHardAsset.selector);
         vm.prank(hardAssetManger);
         forkableBridge.transferHardAssetsToChild(
             address(gasTokenAddress),


### PR DESCRIPTION
closes #144
(wrapped tokens from L2 need to be send burn and send to the children bridges by their users).
(gasToken can be burned all at once with the current implementation and send to one child in one transaction + to the other child in a second transaction).
(L1 tokens - hard assets -  will be send to the child contract via the call from the hardasset manager.)