### PR TITLE
fix bridging todo

### DIFF
--- a/contracts/L2ForkArbitrator.sol
+++ b/contracts/L2ForkArbitrator.sol
@@ -151,7 +151,7 @@ contract L2ForkArbitrator is IBridgeMessageReceiver {
         bridge.bridgeAsset{value: forkFee}(
             uint32(0),
             moneyBox,
-            forkFee,
+            forkFee, // must be equal to msg.value
             address(0), // Empty address for the native token
             true,
             permitData

--- a/contracts/L2ForkArbitrator.sol
+++ b/contracts/L2ForkArbitrator.sol
@@ -151,7 +151,7 @@ contract L2ForkArbitrator is IBridgeMessageReceiver {
         bridge.bridgeAsset{value: forkFee}(
             uint32(0),
             moneyBox,
-            forkFee, // TODO: Should this be 0 since we already sent the forkFee as msg.value?
+            forkFee,
             address(0), // Empty address for the native token
             true,
             permitData


### PR DESCRIPTION
In the bridging contract we have:

if (msg.value != amount) {
                revert AmountDoesNotMatchMsgValue();
            }
           
 Hence, the interface to bridge was called correctly.