### PR TITLE
optimize the number of optimizer runs

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -3,7 +3,7 @@ src = "contracts"
 out = "out"
 libs = ["node_modules", "lib"]
 optimizer = true
-optimizer_runs = 200
+optimizer_runs = 500
 evm_version = "london"
 solc_version = "0.8.20"
 

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -49,7 +49,7 @@ module.exports = {
                 settings: {
                     optimizer: {
                         enabled: true,
-                        runs: 200,
+                        runs: 500,
                     },
                 },
             },


### PR DESCRIPTION
With the current contract size, we can increase the runs close to 500 before breaking the code limit for the forkable bridge contract.

Code limit can be checked by forge build --sizes.

