### PR TITLE
Make tests fail on compilation warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Run Forge tests
         run: |
-          forge test -vvv
+          forge test --deny-warnings -vvv  
         id: test
 
 

--- a/test/ForkableBridge.t.sol
+++ b/test/ForkableBridge.t.sol
@@ -90,7 +90,6 @@ contract ForkableBridgeTest is Test {
         bytes32 newDepositRoot = forkableBridge.getDepositRoot();
 
         // If globalExitRootManager is called, it should revert since there is no mock in place.
-        address forkmanager = forkableBridge.forkmanager();
         vm.expectRevert();
         vm.prank(forkmanager);
         forkableBridge.createChildren();


### PR DESCRIPTION
We merged the following warning:

```
Warning (2519): This declaration shadows an existing declaration.
  --> test/ForkableBridge.t.sol:93:9:
   |
93 |         address forkmanager = forkableBridge.forkmanager();
   |         ^^^^^^^^^^^^^^^^^^^
Note: The shadowed declaration is here:
  --> test/ForkableBridge.t.sol:22:5:
   |
22 |     address public forkmanager = address(0x123);
```