### PR TITLE
Arbitration proceedings control management

### DIFF
--- a/contracts/L1GlobalForkRequester.sol
+++ b/contracts/L1GlobalForkRequester.sol
@@ -60,12 +60,9 @@ contract L1GlobalForkRequester {
             token
         );
 
-        // If for some reason we've already got part of a payment, include it.
-        uint256 initialBalance = failedRequests[token][beneficiary][requestId]
-            .amount;
-
-        uint256 transferredBalance = initialBalance +
-            IForkonomicToken(token).balanceOf(moneyBox);
+        uint256 transferredBalance = IForkonomicToken(token).balanceOf(
+            moneyBox
+        );
 
         if (moneyBox.code.length == 0) {
             new MoneyBox{salt: salt}(token);
@@ -90,10 +87,6 @@ contract L1GlobalForkRequester {
             transferredBalance >= forkingManager.arbitrationFee() &&
             !forkingManager.isForkingInitiated()
         ) {
-            if (initialBalance > 0) {
-                delete (failedRequests[token][beneficiary][requestId]);
-            }
-
             IForkonomicToken(token).approve(
                 address(forkingManager),
                 transferredBalance

--- a/contracts/L2ForkArbitrator.sol
+++ b/contracts/L2ForkArbitrator.sol
@@ -145,6 +145,10 @@ contract L2ForkArbitrator is IBridgeMessageReceiver {
             revert ForkInProgress(); // Forking over something else
         }
 
+        if (msg.sender != arbitrationRequests[question_id].payer) {
+            revert WrongSender();
+        }
+
         RequestStatus status = arbitrationRequests[question_id].status;
         if (
             status != RequestStatus.QUEUED &&
@@ -278,6 +282,10 @@ contract L2ForkArbitrator is IBridgeMessageReceiver {
         // For simplicity we won't let you cancel until forking is sorted, as you might retry and keep failing for the same reason
         if (isForkInProgress) {
             revert ForkInProgress();
+        }
+
+        if (msg.sender != arbitrationRequests[question_id].payer) {
+            revert WrongSender();
         }
 
         RequestStatus status = arbitrationRequests[question_id].status;

--- a/test/AdjudicationIntegration.t.sol
+++ b/test/AdjudicationIntegration.t.sol
@@ -712,6 +712,13 @@ contract AdjudicationIntegrationTest is Test {
             "Not in forking state"
         );
 
+        vm.expectRevert(L2ForkArbitrator.WrongSender.selector);
+        l2ForkArbitrator.requestActivateFork(removalQuestionId);
+
+        vm.expectRevert(L2ForkArbitrator.WrongSender.selector);
+        l2ForkArbitrator.cancelArbitration(removalQuestionId);
+
+        vm.prank(user2);
         l2ForkArbitrator.cancelArbitration(removalQuestionId);
         assertEq(forkFee, l2ForkArbitrator.refundsDue(user2));
 


### PR DESCRIPTION
This PR gives the arbitration payer full control over proceedings of their arbitration in the L2ForkArbitrator.

In the L1ForkRequester, the a failed requests always has to be returned to the payee and it needs to be restarted on the L2. There are also no longer options for topups, but I think this is also not needed, as the L2ForkRequestor always checks for the correct arbitrationfee amount.

Also this PR prevents a gasAuction in the L2ForkArbtirator by giving only the payee the power to either cancel or submit their forkrequest. 

closes: #170