### PR TITLE
Remove duplication of deployment steps in executeFork, make a function that can do the genesis deploy from the ForkingManager

### DIFF
--- a/contracts/interfaces/IForkingManager.sol
+++ b/contracts/interfaces/IForkingManager.sol
@@ -48,19 +48,12 @@ interface IForkingManager is IForkableStructure {
 
     function isForkingExecuted() external returns (bool);
 
-    // Struct that holds an address pair used to store the new child contracts
-    struct AddressPair {
-        address one;
-        address two;
-    }
-
-    // Struct containing the addresses of the new instances
-    struct NewInstances {
-        AddressPair forkingManager;
-        AddressPair bridge;
-        AddressPair zkEVM;
-        AddressPair forkonomicToken;
-        AddressPair globalExitRoot;
+    struct NewInstance {
+        address zkEVM;
+        address bridge;
+        address forkonomicToken;
+        address globalExitRoot;
+        address forkingManager;
     }
 
     /**

--- a/test/ForkingManager.t.sol
+++ b/test/ForkingManager.t.sol
@@ -88,70 +88,16 @@ contract ForkingManagerTest is Test {
     event Transfer(address indexed from, address indexed to, uint256 tokenId);
 
     function setUp() public {
-        bridgeImplementation = address(new ForkableBridge());
-        bridge = ForkableBridge(
-            address(
-                new TransparentUpgradeableProxy(bridgeImplementation, admin, "")
-            )
-        );
         forkmanagerImplementation = address(new ForkingManager());
-        forkmanager = ForkingManager(
-            address(
-                new TransparentUpgradeableProxy(
-                    forkmanagerImplementation,
-                    admin,
-                    ""
-                )
-            )
-        );
-        zkevmImplementation = address(new ForkableZkEVM());
-        zkevm = ForkableZkEVM(
-            address(
-                new TransparentUpgradeableProxy(zkevmImplementation, admin, "")
-            )
-        );
+        bridgeImplementation = address(new ForkableBridge());
         forkonomicTokenImplementation = address(new ForkonomicToken());
-        forkonomicToken = ForkonomicToken(
-            address(
-                new TransparentUpgradeableProxy(
-                    forkonomicTokenImplementation,
-                    admin,
-                    ""
-                )
-            )
-        );
+        zkevmImplementation = address(new ForkableZkEVM());
         globalExitRootImplementation = address(new ForkableGlobalExitRoot());
-        globalExitRoot = ForkableGlobalExitRoot(
-            address(
-                new TransparentUpgradeableProxy(
-                    globalExitRootImplementation,
-                    admin,
-                    ""
-                )
-            )
-        );
+
         ChainIdManager chainIdManager = new ChainIdManager(initialChainId);
         chainIdManagerAddress = address(chainIdManager);
-        globalExitRoot.initialize(
-            address(forkmanager),
-            address(0x0),
-            address(zkevm),
-            address(bridge),
-            bytes32(0),
-            bytes32(0)
-        );
-        bridge.initialize(
-            address(forkmanager),
-            address(0x0),
-            networkID,
-            globalExitRoot,
-            address(zkevm),
-            address(forkonomicToken),
-            false,
-            hardAssetManger,
-            0,
-            depositTree
-        );
+
+        uint64 chainId = chainIdManager.getNextUsableChainId();
 
         IPolygonZkEVM.InitializePackedParameters
             memory initializePackedParameters = IPolygonZkEVM
@@ -161,40 +107,51 @@ contract ForkingManagerTest is Test {
                     pendingStateTimeout: pendingStateTimeout,
                     trustedAggregator: trustedAggregator,
                     trustedAggregatorTimeout: trustedAggregatorTimeout,
-                    chainID: chainIdManager.getNextUsableChainId(),
+                    chainID: chainId,
                     forkID: forkID,
                     lastVerifiedBatch: 0
                 });
-        zkevm.initialize(
-            address(forkmanager),
-            address(0x0),
-            initializePackedParameters,
-            genesisRoot,
-            "trustedSequencerURL",
-            "test network",
-            "0.0.1",
-            globalExitRoot,
-            IERC20Upgradeable(address(forkonomicToken)),
-            rollupVerifierMock,
-            IPolygonZkEVMBridge(address(bridge))
+
+        ForkingManager.DeploymentConfig memory deploymentConfig = ForkingManager
+            .DeploymentConfig({
+                genesisRoot: genesisRoot,
+                trustedSequencerURL: "trustedSequencerURL",
+                networkName: "my network",
+                version: "0.0.1",
+                rollupVerifier: IVerifierRollup(rollupVerifierMock),
+                minter: address(this),
+                tokenName: "Fork",
+                tokenSymbol: "FORK",
+                arbitrationFee: arbitrationFee,
+                chainIdManager: chainIdManagerAddress,
+                forkPreparationTime: forkPreparationTime,
+                hardAssetManager: hardAssetManger,
+                lastUpdatedDepositCount: 0,
+                lastMainnetExitRoot: bytes32(0),
+                lastRollupExitRoot: bytes32(0),
+                parentGlobalExitRoot: address(0),
+                parentZkEVM: address(0),
+                parentForkonomicToken: address(0),
+                parentBridge: address(0)
+            });
+
+        forkmanager = ForkingManager(
+            ForkingManager(forkmanagerImplementation).spawnInstance(
+                admin,
+                zkevmImplementation,
+                bridgeImplementation,
+                forkonomicTokenImplementation,
+                globalExitRootImplementation,
+                chainId,
+                deploymentConfig,
+                initializePackedParameters
+            )
         );
-        forkmanager.initialize(
-            address(zkevm),
-            address(bridge),
-            address(forkonomicToken),
-            address(0x0),
-            address(globalExitRoot),
-            arbitrationFee,
-            chainIdManagerAddress,
-            forkPreparationTime
-        );
-        forkonomicToken.initialize(
-            address(forkmanager),
-            address(0x0),
-            address(this),
-            "Fork",
-            "FORK"
-        );
+
+        bridge = ForkableBridge(forkmanager.bridge());
+        zkevm = ForkableZkEVM(forkmanager.zkEVM());
+        forkonomicToken = ForkonomicToken(forkmanager.forkonomicToken());
+        globalExitRoot = ForkableGlobalExitRoot(forkmanager.globalExitRoot());
     }
 
     function testForkingStatusFunctions() public {


### PR DESCRIPTION
We'd ended up with a lot of duplication of all the `initialize` steps passing a lot of similar arguments into various contracts:

 * Twice in executeFork
 * In lots of tests
 * Again in the deployment scripts, which we also don't have tests for (although they're thorough about `assert` checks)

This PR channels all initialization through a single function, and creates a `spawnInstance` function that can be called against the `ForkingManager` implementation to do the deployment of all the other forkable parts.

Next step (apart from tidying up) would be to replace parts of the JavaScript deployment scripts with a call to `spawnInstance`.

